### PR TITLE
Update debian GPG key

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -11,21 +11,21 @@ class jenkins::repo::debian
 
   if $::jenkins::lts  {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian-stable',
+      location    => 'https://pkg.jenkins.io/debian-stable',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      key         => '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
+      key_source  => 'https://pkg.jenkins.io/debian/jenkins.io.key',
       include_src => false,
     }
   }
   else {
     apt::source { 'jenkins':
-      location    => 'http://pkg.jenkins-ci.org/debian',
+      location    => 'https://pkg.jenkins.io/debian',
       release     => 'binary/',
       repos       => '',
-      key         => '150FDE3F7787E7D11EF4E12A9B7D32F2D50582E6',
-      key_source  => 'http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key',
+      key         => '62A9756BFD780C377CF24BA8FCEF32E745F2C3D5',
+      key_source  => 'https://pkg.jenkins.io/debian/jenkins.io.key',
       include_src => false,
     }
   }


### PR DESCRIPTION
Please make a new `1.7.0-rosbuildfarm3` branch and I'll re-target this PR at that.

This happened upstream in voxpupuli/puppet-jenkins#972, but the file has diverged substantially from our copy, so I had to change a lot more.

https://www.jenkins.io/blog/2020/07/27/repository-signing-keys-changing/
https://pkg.jenkins.io/debian-stable/

I did a test deployment to verify that the Jenkins deb installation problems were resolved by this change.